### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -164,6 +164,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
         libwww-perl \
         libxml-parser-lite-perl \
         libxml-simple-perl \
+        libnet-sip-perl \
         libxml-stream-perl \
     && cpanm \
         Net::MQTT::Constants \


### PR DESCRIPTION
libnet-sip-perl library is needed for fhem module 96_SIP.pm