### PR TITLE
Add Crypt::Random installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
         sudo \
         telnet \
         telnet-ssl \
+        unzip \
         usbutils \
         wget \
         \
@@ -168,6 +169,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
         libnet-sip-perl \
         libxml-stream-perl \
     && cpanm \
+        Crypt::Random \
         Net::MQTT::Constants \
         Net::MQTT::Simple \
     && if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "i386" ]; then \
@@ -178,6 +180,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && apt-get purge -qqy \
         build-essential \
         cpanminus \
+        unzip \
     && apt-get autoremove -qqy && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,6 +112,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
         libcgi-pm-perl \
         libclass-dbi-mysql-perl \
         libclass-isa-perl \
+        libclass-loader-perl \
         libcommon-sense-perl \
         libconvert-base32-perl \
         libcrypt-*-perl \
@@ -169,9 +170,12 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
         libnet-sip-perl \
         libxml-stream-perl \
     && cpanm \
-        Crypt::Random \
         Net::MQTT::Constants \
         Net::MQTT::Simple \
+    && if [ "${ARCH}" != "i386" ]; then \
+         cpanm \
+           Crypt::Random \
+       ; fi \
     && if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "i386" ]; then \
          cpanm \
            Crypt::Cipher::AES \


### PR DESCRIPTION
Explicitly install Crypt::Random for EnOcean encryption support. The Perl package depends on Math::Pari and Class::Loader.

fhem logs: EnOcean Cryptographic functions are not available.

fhem check:
# perl -e "use Crypt::Random qw(makerandom)"
Can't locate Crypt/Random.pm in @INC (you may need to install the Crypt::Random module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.24.1 /usr/local/share/perl/5.24.1 /usr/lib/x86_64-linux-gnu/perl5/5.24 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.24 /usr/share/perl/5.24 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base) at -e line 1.
BEGIN failed--compilation aborted at -e line 1.