### PR TITLE
fix filenames for capability tests

### DIFF
--- a/src/99_DockerImageInfo.pm
+++ b/src/99_DockerImageInfo.pm
@@ -81,11 +81,11 @@ sub DockerImageInfo_GetImageInfo() {
     readingsBulkUpdateIfChanged( $defs{$n}, "container.hostname",
         `cat /etc/hostname` );
     readingsBulkUpdateIfChanged( $defs{$n}, "container.cap.e",
-        `cat /docker.cap.e` );
+        `cat /docker.container.cap.e` );
     readingsBulkUpdateIfChanged( $defs{$n}, "container.cap.p",
-        `cat /docker.cap.p` );
+        `cat /docker.container.cap.p` );
     readingsBulkUpdateIfChanged( $defs{$n}, "container.cap.i",
-        `cat /docker.cap.i` );
+        `cat /docker.container.cap.i` );
     readingsBulkUpdateIfChanged( $defs{$n}, "container.id",
         `cat /docker.container.id` );
     readingsBulkUpdateIfChanged( $defs{$n}, "container.privileged",


### PR DESCRIPTION
according to

captest --text | grep -P "^Effective:" | cut -d " " -f 2- | sed "s/, /\n/g" | sort | sed ':a;N;$!ba;s/\n/,/g' > /docker.container.cap.e
captest --text | grep -P "^Permitted:" | cut -d " " -f 2- | sed "s/, /\n/g" | sort | sed ':a;N;$!ba;s/\n/,/g' > /docker.container.cap.p
captest --text | grep -P "^Inheritable:" | cut -d " " -f 2- | sed "s/, /\n/g" | sort | sed ':a;N;$!ba;s/\n/,/g' > /docker.container.cap.i

in entry.sh

