### PR TITLE
correcting quotation marks

### DIFF
--- a/src/entry.sh
+++ b/src/entry.sh
@@ -256,8 +256,8 @@ find /dev/ -name "ttyACM*" -exec chmod --recursive --quiet g+rw {} \;
 find /dev/ -name "ttyUSB*" -exec chmod --recursive --quiet g+rw {} \;
 (( i++ ))
 echo "$i. Correcting group ownership for /dev/serial/* ..."
-chown --recursive --quiet --no-dereference .dialout /dev/serial/by-id/*
-chmod --recursive --quiet g+rw /dev/serial/by-id/*
+find /dev/serial/by-id/ -exec chown --recursive --quiet --no-dereference .dialout {} \;
+find /dev/serial/by-id/ -exec chmod --recursive --quiet g+rw {} \;
 (( i++ ))
 if [[ "$(find /dev/ -name "gpio*")" -ne "" || -d /sys/devices/virtual/gpio || -d /sys/devices/platform/gpio-sunxi/gpio || /sys/class/gpio ]]; then
   echo "$i. Found GPIO: Correcting group permissions in /dev and /sys to 'gpio' with GID ${GPIO_GID} ..."

--- a/src/entry.sh
+++ b/src/entry.sh
@@ -256,8 +256,8 @@ find /dev/ -name "ttyACM*" -exec chmod --recursive --quiet g+rw {} \;
 find /dev/ -name "ttyUSB*" -exec chmod --recursive --quiet g+rw {} \;
 (( i++ ))
 echo "$i. Correcting group ownership for /dev/serial/* ..."
-chown --recursive --quiet --no-dereference .dialout "/dev/serial/by-id/*"
-chmod --recursive --quiet g+rw "/dev/serial/by-id/*"
+chown --recursive --quiet --no-dereference .dialout /dev/serial/by-id/*
+chmod --recursive --quiet g+rw /dev/serial/by-id/*
 (( i++ ))
 if [[ "$(find /dev/ -name "gpio*")" -ne "" || -d /sys/devices/virtual/gpio || -d /sys/devices/platform/gpio-sunxi/gpio || /sys/class/gpio ]]; then
   echo "$i. Found GPIO: Correcting group permissions in /dev and /sys to 'gpio' with GID ${GPIO_GID} ..."


### PR DESCRIPTION
Path has to be passed without quotation marks.

root@6c5e6acdc64b:/opt/fhem# chown --recursive --no-dereference .dialout "/dev/serial/by-id/*"
chown: cannot access '/dev/serial/by-id/*': No such file or directory
root@6c5e6acdc64b:/opt/fhem# chmod --recursive g+rw "/dev/serial/by-id/*"
chmod: cannot access '/dev/serial/by-id/*': No such file or directory

