### PR TITLE
Don't publish pull request image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -242,6 +242,7 @@ jobs:
            ${{ runner.os }}-buildx-
 
       - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v1 
         with:
           registry: ghcr.io
@@ -255,7 +256,7 @@ jobs:
           load: false  
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm/v7,linux/arm64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           tags: |
@@ -288,7 +289,7 @@ jobs:
           load: false  
           file: ./Dockerfile
           platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           tags: |


### PR DESCRIPTION
Avoid pushing if we are running a pull request

because this adds additional tags with the pr name 
and also causes to break the action if the pr comes from outside our repository.

Examples are prs from dependabot which will faile because the do not have access to the credentials to login to the container registry

