### PR TITLE
Remove ARM v6 from Build Jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,7 +239,7 @@ jobs:
           context: .
           load: false  
           file: ./${{ matrix.dockerfile }}
-          platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
+          platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max


### PR DESCRIPTION
Removed armv6, because debian ships no image for that plattform

