### PR TITLE
fix[dockertag]: latest only for bullseye

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/fhem-docker
             fhem/fhem
           flavor: |
-              latest= ${{ fromJSON('["auto", "false"]')[github.event.release.prerelease == 1] }}
+              latest= ${{ fromJSON('["auto", "false"]')[github.event.release.prerelease == 1 || endsWith(matrix.dockerfile, 'Dockerfile')] }}
           tags: |
             type=semver,pattern={{version}},suffix=${{ fromJSON('["-bullseye", "-buster"]')[endsWith(matrix.dockerfile, 'Dockerfile')] }}
             type=semver,pattern={{major}},enable=${{ github.event.release.prerelease == 0 }},suffix=${{ fromJSON('["-bullseye", "-buster"]')[endsWith(matrix.dockerfile, 'Dockerfile')] }}


### PR DESCRIPTION
 - latest tag is only provided for bullseye image not for buster

