### PR TITLE
fix[dockerlogs]: Fixes a bug, that newlines are added to docker logs if there are no logs from FHEM

### DIFF
--- a/src/entry.sh
+++ b/src/entry.sh
@@ -459,7 +459,7 @@ function PrintNewLines {
 
     if [ ${#logArray[@]} -eq 0 ]; then
       MAXLINES=$( wc -l < "${LOGFILENAME}" )
-      [ ${OLDLINES} -gt ${MAXLINES} ] && OLDLINES=-1  # logfile rotation
+      [ ${OLDLINES} -gt ${MAXLINES} ] && OLDLINES=0  # logfile rotation
     else
       [ -n "$1" ] && printf '%s\n' "${logArray[@]}" | grep -q -e "$1" && FOUND=true || FOUND=false
       printf '%s\n' "${logArray[@]}" 

--- a/src/entry.sh
+++ b/src/entry.sh
@@ -456,12 +456,13 @@ function PrintNewLines {
   LOGFILENAME=$( date +"${LOGFILE}" )
   if [ -s "${LOGFILENAME}" ]; then
     mapfile -t logArray < <(tail -n "+$((${OLDLINES} + 1))" "${LOGFILENAME}" )
-    printf '%s\n' "${logArray[@]}" 
-    [ -n "$1" ] && printf '%s\n' "${logArray[@]}" | grep -q -e "$1" && FOUND=true || FOUND=false
+
     if [ ${#logArray[@]} -eq 0 ]; then
       MAXLINES=$( wc -l < "${LOGFILENAME}" )
-  	  [ ${OLDLINES} -gt ${MAXLINES} ] && OLDLINES=-1  # logfile rotation
+      [ ${OLDLINES} -gt ${MAXLINES} ] && OLDLINES=-1  # logfile rotation
     else
+      [ -n "$1" ] && printf '%s\n' "${logArray[@]}" | grep -q -e "$1" && FOUND=true || FOUND=false
+      printf '%s\n' "${logArray[@]}" 
       OLDLINES=$((${OLDLINES} + ${#logArray[@]} ))
     fi
   fi


### PR DESCRIPTION
Fixes working with the logarray if the array is empty.

 - avoids printing of unneeded newlins in the docker logs

