### PR TITLE
Fix dependency install from cpanfile if not a amd64 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,6 +117,67 @@ jobs:
           cache-to: type=gha,mode=max,scope=base_linux/${{ matrix.platform }}-${{ matrix.dockerfile }}
           tags: baseonly
 
+  base_cpan_build:
+    needs: [get_dependencies, base_build]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dockerfile: [-bullseye, -threaded-bullseye]
+        platform: [arm/v7, arm64, 386]
+    steps:
+      - name: Checkout this repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4.4.1
+
+      - name: Get git vars
+        shell: bash
+        run: |
+          echo "IMAGE_VERSION=$( git describe --tags --dirty --match "v[0-9]*")" >> $GITHUB_OUTPUT
+        id: gitVars
+
+      - name: Prepare SVN repository checkout and variables
+        id: prepareSVN
+        uses: ./.github/workflows/prepare-svn
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: cpanfile-FHEM
+  
+      - uses: actions/download-artifact@v4
+        with:
+          name: cpanfile-3rdParty
+          path: 3rdParty
+          
+      - name: Prepare docker for build and publish
+        id: prepareDOCKER
+        uses: ./.github/workflows/prepare-docker
+        with:
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          GHCR_OWNER: ${{ github.repository_owner }} 
+          GHCR_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}   
+          DOCKERFILE: ${{ matrix.dockerfile }}
+
+      - name: Build base cpan layer for ${{ matrix.platform }}
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          load: true  
+          file: ./Dockerfile${{ matrix.dockerfile }}
+          platforms: linux/${{ matrix.platform }}
+          push: false
+          target: base-cpan
+          cache-from: | 
+            type=gha,scope=base-cpan_linux/${{ matrix.platform }}-${{ matrix.dockerfile }}
+            type=gha,scope=base_linux/${{ matrix.platform }}-${{ matrix.dockerfile }}
+          cache-to: type=gha,mode=max,scope=base-cpan_linux/${{ matrix.platform }}-${{ matrix.dockerfile }}
+          tags: basecpanonly
+    
+            
   test_build:
     # The type of runner that the job will run on
     needs: [get_dependencies, base_build]
@@ -251,7 +312,7 @@ jobs:
 
   published_build:
     runs-on: ubuntu-latest
-    needs: test_build
+    needs: [test_build, base_cpan_build]
     strategy:
       matrix:
         dockerfile: [-bullseye, -threaded-bullseye]
@@ -319,9 +380,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           target: with-fhem-python-nodejs
           cache-from: | 
-            type=gha,scope=base_linux/arm64-${{ matrix.dockerfile }}
-            type=gha,scope=base_linux/amd64-${{ matrix.dockerfile }}
-            type=gha,scope=base_linux/armv7-${{ matrix.dockerfile }}
+            type=gha,scope=base-cpan_linux/arm64-${{ matrix.dockerfile }}
+            type=gha,scope=base-cpan_linux/arm/v7-${{ matrix.dockerfile }}
             type=gha,scope=full_linux/amd64-${{ matrix.dockerfile }}
             type=gha,scope=full_linux/cross-${{ matrix.dockerfile }}
           cache-to: type=gha,mode=max,scope=full_linux/cross-${{ matrix.dockerfile }}
@@ -365,7 +425,7 @@ jobs:
           cache-from: | 
             type=gha,scope=base_linux/arm64-${{ matrix.dockerfile }}
             type=gha,scope=base_linux/amd64-${{ matrix.dockerfile }}
-            type=gha,scope=base_linux/armv7-${{ matrix.dockerfile }}
+            type=gha,scope=base_linux/arm/v7-${{ matrix.dockerfile }}
             type=gha,scope=full_linux/amd64-${{ matrix.dockerfile }}
             type=gha,scope=full_linux/cross-${{ matrix.dockerfile }}
             type=gha,scope=base_linux/cross-${{ matrix.dockerfile }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,8 +38,7 @@ jobs:
           perl-version: "5.38"
           install-modules-with: cpanm
           install-modules-args: --notest
-          install-modules: PPI Perl::PrereqScanner::NotQuiteLite File::Find::Rule List::MoreUtils CPAN::Meta Module::CPANfile CPAN::Meta::Merge Scalar::Util
-          
+          install-modules: PPI Perl::PrereqScanner::NotQuiteLite File::Path File::Find::Rule List::MoreUtils CPAN::Meta Module::CPANfile CPAN::Meta::Merge Scalar::Util
 
       - name: clone 3rdparty repositories at github
         run: | 
@@ -48,6 +47,15 @@ jobs:
           cd ./3rdparty
           printf "%s\n" "${REPO_URLS[@]}" | xargs -I {} -P3 sh -c 'echo "{}: $(basename $(dirname {}))/$(basename {})"; git clone "{}" "$(basename $(dirname {}))/$(basename {})"; '
 
+      - name: Init PPI Cache 
+        uses: actions/cache@v4
+        with:
+          path: .cache/PPI
+          save-always: true
+          restore-keys: |
+            PPI-SVN-
+          key: PPI-SVN-${{ steps.prepareSVN.outputs.FHEM_REVISION_LATEST }}
+    
       - name: "create private modules filter regex"    
         run: |
           echo "FHEM_MODULES=$(perl scripts/get-Packages.pl ./3rdparty ./src/fhem/trunk)"  >> $GITHUB_ENV

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ fhem/log/*
 fhem/restoreDir/*
 .vscode/*
 src/FHEM/trunk/*
+.cache/*

--- a/Dockerfile-bullseye
+++ b/Dockerfile-bullseye
@@ -110,32 +110,32 @@ EOF
 
 FROM base as base-cpan
 # Install all CPAN Modules, needed from FHEM and standard modules
-COPY cpanfile /root/cpanfile
+COPY cpanfile /root/svn/cpanfile
 # Fixup modules which do not work on all platforms and install afterwards
 RUN <<EOF
   if [ "${TARGETPLATFORM}" != "linux/amd64" ] && [ "${TARGETPLATFORM}" != "linux/i386" ]; then 
-    sed -i '/Device::SerialPort/d' root/cpanfile  > /root/cpanfile 
-    sed -i '/Device::Firmata::Constants/d' root/cpanfile  >/root/cpanfile
+    sed -i '/Device::SerialPort/d' /root/svn/cpanfile  > /root/svn/cpanfile
+    sed -i '/Device::Firmata::Constants/d' /root/svn/cpanfile  > /root/svn/cpanfile
   fi
-  cpanm --notest --cpanfile /root/cpanfile --installdeps  .
+  cpanm --notest --cpanfile /root/svn/cpanfile --installdeps  .
   rm -rf /root/.cpanm 
 EOF
 
 RUN <<EOF
-  cpanm --notest --cpanfile /root/cpanfile --installdeps --with-suggests .
+  cpanm --notest --cpanfile /root/svn/cpanfile --installdeps --with-suggests .
   rm -rf /root/.cpanm 
 EOF
 
 # Install all CPAN Modules, needed from 3rd party module repositorys 
-COPY 3rdParty/cpanfile /root/cpanfile_3rdparty
+COPY 3rdParty/cpanfile /root/3rdparty/cpanfile
 # Fixup modules which do not work on all platforms and install afterwards
 RUN <<EOF
   if [ "${TARGETPLATFORM}" != "linux/amd64" ] && [ "${TARGETPLATFORM}" != "linux/i386" ]; then 
-    sed -i '/Device::SerialPort/d' /root/cpanfile_3rdparty  > /root/cpanfile_3rdparty
-    sed -i '/Device::Firmata::Constants/d' /root/cpanfile_3rdparty  > /root/cpanfile_3rdparty
+    sed -i '/Device::SerialPort/d' /root/3rdparty/cpanfile  > /root/3rdparty/cpanfile
+    sed -i '/Device::Firmata::Constants/d' /root/3rdparty/cpanfile  > /root/3rdparty/cpanfile
   fi
 
-  cpanm --notest --cpanfile /root/cpanfile_3rdparty --installdeps --with-suggests .
+  cpanm --notest --cpanfile /root/3rdparty/cpanfile --installdeps --with-suggests .
   rm -rf /root/.cpanm 
 EOF
 

--- a/Dockerfile-bullseye
+++ b/Dockerfile-bullseye
@@ -114,8 +114,8 @@ COPY cpanfile /root/svn/cpanfile
 # Fixup modules which do not work on all platforms and install afterwards
 RUN <<EOF
   if [ "${TARGETPLATFORM}" != "linux/amd64" ] && [ "${TARGETPLATFORM}" != "linux/i386" ]; then 
-    sed -i '/Device::SerialPort/d' /root/svn/cpanfile  > /root/svn/cpanfile
-    sed -i '/Device::Firmata::Constants/d' /root/svn/cpanfile  > /root/svn/cpanfile
+    sed -i '/Device::SerialPort/d' /root/svn/cpanfile  
+    sed -i '/Device::Firmata::Constants/d' /root/svn/cpanfile  
   fi
   cpanm --notest --cpanfile /root/svn/cpanfile --installdeps  .
   rm -rf /root/.cpanm 
@@ -131,8 +131,8 @@ COPY 3rdParty/cpanfile /root/3rdparty/cpanfile
 # Fixup modules which do not work on all platforms and install afterwards
 RUN <<EOF
   if [ "${TARGETPLATFORM}" != "linux/amd64" ] && [ "${TARGETPLATFORM}" != "linux/i386" ]; then 
-    sed -i '/Device::SerialPort/d' /root/3rdparty/cpanfile  > /root/3rdparty/cpanfile
-    sed -i '/Device::Firmata::Constants/d' /root/3rdparty/cpanfile  > /root/3rdparty/cpanfile
+    sed -i '/Device::SerialPort/d' /root/3rdparty/cpanfile  
+    sed -i '/Device::Firmata::Constants/d' /root/3rdparty/cpanfile  
   fi
 
   cpanm --notest --cpanfile /root/3rdparty/cpanfile --installdeps --with-suggests .
@@ -243,7 +243,7 @@ FROM with-fhem as with-fhem-python
 
 RUN <<EOF 
     LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get update 
-    LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get install -qqy --no-install-recommends 
+    LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get install -qqy --no-install-recommends \
       python3 \
       python3-dev \
       python3-pip \

--- a/Dockerfile-bullseye
+++ b/Dockerfile-bullseye
@@ -110,33 +110,32 @@ EOF
 
 FROM base as base-cpan
 # Install all CPAN Modules, needed from FHEM and standard modules
-COPY cpanfile /root/svn/cpanfile
+COPY cpanfile /usr/src/app/core-cpanfile
 # Fixup modules which do not work on all platforms and install afterwards
 RUN <<EOF
   if [ "${TARGETPLATFORM}" != "linux/amd64" ] && [ "${TARGETPLATFORM}" != "linux/i386" ]; then 
-    sed -i '/Device::SerialPort/d' /root/svn/cpanfile  
-    sed -i '/Device::Firmata::Constants/d' /root/svn/cpanfile  
+    sed -i '/Device::SerialPort/d' /usr/src/app/core-cpanfile
+    sed -i '/Device::Firmata::Constants/d' /usr/src/app/core-cpanfile  
   fi
-  cpanm --notest --cpanfile /root/svn/cpanfile --installdeps  .
-  rm -rf /root/.cpanm 
-EOF
+  cpm install --without-test --cpanfile /usr/src/app/core-cpanfile --show-build-log-on-failure --global
+  cpm install --without-test --with-suggests --with-recommends --cpanfile /usr/src/app/core-cpanfile --show-build-log-on-failure --global
 
-RUN <<EOF
-  cpanm --notest --cpanfile /root/svn/cpanfile --installdeps --with-suggests .
-  rm -rf /root/.cpanm 
+  rm -rf /root/.cpanm
+  rm -rf /root/.perl-cpm
 EOF
 
 # Install all CPAN Modules, needed from 3rd party module repositorys 
-COPY 3rdParty/cpanfile /root/3rdparty/cpanfile
+COPY 3rdParty/cpanfile /usr/src/app/3rdparty-cpanfile
 # Fixup modules which do not work on all platforms and install afterwards
 RUN <<EOF
   if [ "${TARGETPLATFORM}" != "linux/amd64" ] && [ "${TARGETPLATFORM}" != "linux/i386" ]; then 
-    sed -i '/Device::SerialPort/d' /root/3rdparty/cpanfile  
-    sed -i '/Device::Firmata::Constants/d' /root/3rdparty/cpanfile  
+    sed -i '/Device::SerialPort/d' /usr/src/app/3rdparty-cpanfile
+    sed -i '/Device::Firmata::Constants/d' /usr/src/app/3rdparty-cpanfile
   fi
 
-  cpanm --notest --cpanfile /root/3rdparty/cpanfile --installdeps --with-suggests .
+  cpm install --cpanfile /usr/src/app/3rdparty-cpanfile --without-test --with-recommends --with-suggests --show-build-log-on-failure --global
   rm -rf /root/.cpanm 
+  rm -rf /root/.perl-cpm
 EOF
 
 

--- a/Dockerfile-threaded-bullseye
+++ b/Dockerfile-threaded-bullseye
@@ -110,33 +110,33 @@ EOF
 
 FROM base as base-cpan
 # Install all CPAN Modules, needed from FHEM and standard modules
-COPY cpanfile /root/svn/cpanfile
+COPY cpanfile /usr/src/app/core-cpanfile
 # Fixup modules which do not work on all platforms and install afterwards
 RUN <<EOF
   if [ "${TARGETPLATFORM}" != "linux/amd64" ] && [ "${TARGETPLATFORM}" != "linux/i386" ]; then 
-    sed -i '/Device::SerialPort/d' /root/svn/cpanfile  
-    sed -i '/Device::Firmata::Constants/d' /root/svn/cpanfile  
+    sed -i '/Device::SerialPort/d' /usr/src/app/core-cpanfile
+    sed -i '/Device::Firmata::Constants/d' /usr/src/app/core-cpanfile  
   fi
-  cpanm --notest --cpanfile /root/svn/cpanfile --installdeps  .
+  cpm install --without-test --cpanfile /usr/src/app/core-cpanfile --show-build-log-on-failure --global
+  cpm install --without-test --with-suggests --with-recommends --cpanfile /usr/src/app/core-cpanfile --show-build-log-on-failure --global
+
   rm -rf /root/.cpanm 
+  rm -rf /root/.perl-cpm/
 EOF
 
-RUN <<EOF
-  cpanm --notest --cpanfile /root/svn/cpanfile --installdeps --with-suggests .
-  rm -rf /root/.cpanm 
-EOF
 
 # Install all CPAN Modules, needed from 3rd party module repositorys 
-COPY 3rdParty/cpanfile /root/3rdparty/cpanfile
+COPY 3rdParty/cpanfile /usr/src/app/3rdparty-cpanfile
 # Fixup modules which do not work on all platforms and install afterwards
 RUN <<EOF
   if [ "${TARGETPLATFORM}" != "linux/amd64" ] && [ "${TARGETPLATFORM}" != "linux/i386" ]; then 
-    sed -i '/Device::SerialPort/d' /root/3rdparty/cpanfile  
-    sed -i '/Device::Firmata::Constants/d' /root/3rdparty/cpanfile  
+    sed -i '/Device::SerialPort/d' /usr/src/app/3rdparty-cpanfile
+    sed -i '/Device::Firmata::Constants/d' /usr/src/app/3rdparty-cpanfile
   fi
 
-  cpanm --notest --cpanfile /root/3rdparty/cpanfile --installdeps --with-suggests .
+  cpm install --cpanfile /usr/src/app/3rdparty-cpanfile --without-test --with-recommends --with-suggests --show-build-log-on-failure --global
   rm -rf /root/.cpanm 
+  rm -rf /root/.perl-cpm/
 EOF
 
 

--- a/Dockerfile-threaded-bullseye
+++ b/Dockerfile-threaded-bullseye
@@ -110,32 +110,32 @@ EOF
 
 FROM base as base-cpan
 # Install all CPAN Modules, needed from FHEM and standard modules
-COPY cpanfile /root/cpanfile
+COPY cpanfile /root/svn/cpanfile
 # Fixup modules which do not work on all platforms and install afterwards
 RUN <<EOF
   if [ "${TARGETPLATFORM}" != "linux/amd64" ] && [ "${TARGETPLATFORM}" != "linux/i386" ]; then 
-    sed -i '/Device::SerialPort/d' root/cpanfile  > /root/cpanfile 
-    sed -i '/Device::Firmata::Constants/d' root/cpanfile  >/root/cpanfile
+    sed -i '/Device::SerialPort/d' /root/svn/cpanfile  
+    sed -i '/Device::Firmata::Constants/d' /root/svn/cpanfile  
   fi
-  cpanm --notest --cpanfile /root/cpanfile --installdeps  .
+  cpanm --notest --cpanfile /root/svn/cpanfile --installdeps  .
   rm -rf /root/.cpanm 
 EOF
 
 RUN <<EOF
-  cpanm --notest --cpanfile /root/cpanfile --installdeps --with-suggests .
+  cpanm --notest --cpanfile /root/svn/cpanfile --installdeps --with-suggests .
   rm -rf /root/.cpanm 
 EOF
 
 # Install all CPAN Modules, needed from 3rd party module repositorys 
-COPY 3rdParty/cpanfile /root/cpanfile_3rdparty
+COPY 3rdParty/cpanfile /root/3rdparty/cpanfile
 # Fixup modules which do not work on all platforms and install afterwards
 RUN <<EOF
   if [ "${TARGETPLATFORM}" != "linux/amd64" ] && [ "${TARGETPLATFORM}" != "linux/i386" ]; then 
-    sed -i '/Device::SerialPort/d' /root/cpanfile_3rdparty  > /root/cpanfile_3rdparty
-    sed -i '/Device::Firmata::Constants/d' /root/cpanfile_3rdparty  > /root/cpanfile_3rdparty
+    sed -i '/Device::SerialPort/d' /root/3rdparty/cpanfile  
+    sed -i '/Device::Firmata::Constants/d' /root/3rdparty/cpanfile  
   fi
 
-  cpanm --notest --cpanfile /root/cpanfile_3rdparty --installdeps --with-suggests .
+  cpanm --notest --cpanfile /root/3rdparty/cpanfile --installdeps --with-suggests .
   rm -rf /root/.cpanm 
 EOF
 
@@ -243,7 +243,7 @@ FROM with-fhem as with-fhem-python
 
 RUN <<EOF 
     LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get update 
-    LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get install -qqy --no-install-recommends 
+    LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get install -qqy --no-install-recommends \
       python3 \
       python3-dev \
       python3-pip \

--- a/scripts/get-Packages.pl
+++ b/scripts/get-Packages.pl
@@ -5,7 +5,17 @@ use PPI;
 use File::Find::Rule;
 use List::MoreUtils qw(uniq);
 # use Data::Dumper;
+use File::Path qw(make_path);
 
+my $PPICacheDir;
+BEGIN {
+    $PPICacheDir = '.cache/PPI';
+    unless(-d $PPICacheDir) {
+        make_path($PPICacheDir) or die qq[Directory $PPICacheDir coldn't be created: $!];
+    }
+};
+
+use PPI::Cache path => $PPICacheDir;
 
 my @directories = @ARGV;
 
@@ -20,7 +30,7 @@ foreach my $directory (@directories) {
 
     foreach my $file (@files) {
 
-        my $document = PPI::Document->new($file);
+        my $document = PPI::Document->new($file, readonly => 1);
         next unless $document;
         # Alle package-Anweisungen in der Datei finden
         my $package_statements = $document->find('PPI::Statement::Package');


### PR DESCRIPTION
- Updated parseMETAJson
  - no fixpups, use prereqs JSON
- Updated Dockerfile
  - copy fhem core and 3rdparty cpanfiles to different directorys and name them cpanfile
- cache for PPI parser