### PR TITLE
Healthcheck timeout handling

### DIFF
--- a/src/health-check.sh
+++ b/src/health-check.sh
@@ -56,6 +56,8 @@ echo "$$" > $PID_FILE
 
 while IFS= read -r fhemUrl; do
   fhemwebState=$( curl \
+                    --connect-timeout 5 \
+                    --max-time 8 \
                     --silent \
                     --insecure \
                     --output /dev/null \

--- a/src/tests/bats/health-check.bats
+++ b/src/tests/bats/health-check.bats
@@ -63,6 +63,8 @@ teardown() {
         ((c++)) && ((c==50)) && echo "# fhem did not start" && break
     done
     sleep 5
+    #cat $FHEM_CFG_FILE
+    cat ${LOG_FILE}
     assert_file_contains /tmp/health-check.urls "http://localhost:8083"
 
     run timeout 15 /health-check.sh


### PR DESCRIPTION
Added a timeout handling to curl, to avoid blocking the loop and causing to much failures