### PR TITLE
fix pull_policy indentation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,7 @@ services:
         RUN <<EOF
           cpm install --show-build-log-on-failure --configure-timeout=360 --workers=$(nproc) --local-lib-contained /usr/src/app/3rdparty/  << YOUR PAACKAGE NAME >>
         EOF
-      pull_policy: build
+    pull_policy: build
     restart: always
     networks:
       - net
@@ -142,7 +142,7 @@ services:
           LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get install -qqy --no-install-recommends <DEBIAN PACKAGENAME>
           LC_ALL=C apt-get autoremove -qqy && LC_ALL=C apt-get clean 
         EOF
-      pull_policy: build
+    pull_policy: build
     restart: always
     networks:
       - net
@@ -161,7 +161,7 @@ services:
           npm install -g --unsafe-perm --production <NPM PACKAGENAME> 
           npm cache clean --force
         EOF
-      pull_policy: build
+    pull_policy: build
     restart: always
     networks:
       - net
@@ -180,7 +180,7 @@ services:
         RUN <<EOF
           pip3 install --no-cache-dir <PIP PACKAGENAME>
         EOF
-      pull_policy: build
+    pull_policy: build
     restart: always
     networks:
       - net

--- a/migration.md
+++ b/migration.md
@@ -41,7 +41,7 @@ And add these lines to build a new image which your custom extension in your com
              RUN <<EOF
              # Here you can add your custom build commands, installing every software you want
              EOF
-         pull_policy: build
+        pull_policy: build
 
 
 


### PR DESCRIPTION
The indentation for pull_policy in the sample compose file and migration.md is wrong. It needs to a [services top-level element](https://docs.docker.com/reference/compose-file/services/#pull_policy).
[As one user experienced here](https://forum.fhem.de/index.php?topic=89745.msg1324180#msg1324180) this results in
```validating […]/docker-compose.yml: services.fhem.build Additional property pull_policy is not allowed ```