### PR TITLE
Fix Renovate configuration syntax

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -37,7 +37,7 @@
       "matchPackageNames": ["perl"],
       "matchUpdateTypes": ["patch", "pin", "digest"],
       "automerge": true,
-      "commitMessageExtra": "to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMinor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}}"
+      "commitMessageExtra": "to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMinor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}}",
       "minimumReleaseAge": "1 days",
     }
   ]


### PR DESCRIPTION
## Summary

- Fix the invalid `renovate.json5` syntax that prevents Renovate from parsing the repository configuration.
- Add the missing comma after `commitMessageExtra` in the Docker digest package rule.

## Validation

- `node -e "const fs=require('fs'); const JSON5=require('json5'); JSON5.parse(fs.readFileSync('renovate.json5','utf8')); console.log('renovate.json5 parses as JSON5')"`
- `npx --yes --package node@24 --package renovate renovate-config-validator renovate.json5`

Closes #438