### PR TITLE
Run armv7 CPAN builds on arm64 runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,7 +163,7 @@ jobs:
         include:
           - dockerfile: -bookworm
             platform: arm/v7
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
             setup_qemu: "true"
           - dockerfile: -bookworm
             platform: arm64
@@ -175,7 +175,7 @@ jobs:
             setup_qemu: "true"
           - dockerfile: -threaded-bookworm
             platform: arm/v7
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
             setup_qemu: "true"
           - dockerfile: -threaded-bookworm
             platform: arm64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,7 +163,7 @@ jobs:
         include:
           - dockerfile: -bookworm
             platform: arm/v7
-            runner: ubuntu-24.04
+            runner: ubuntu-24.04-arm
             setup_qemu: "true"
           - dockerfile: -bookworm
             platform: arm64
@@ -175,7 +175,7 @@ jobs:
             setup_qemu: "true"
           - dockerfile: -threaded-bookworm
             platform: arm/v7
-            runner: ubuntu-24.04
+            runner: ubuntu-24.04-arm
             setup_qemu: "true"
           - dockerfile: -threaded-bookworm
             platform: arm64


### PR DESCRIPTION
## What changed

- Pin the `arm/v7` entries in the `cpan_build` matrix to `ubuntu-24.04-arm`.
- Keep QEMU enabled for the 32-bit ARMv7 Docker target.
- Leave the native `arm64` entries on `ubuntu-24.04-arm` as before.

## Why

Running the ARMv7 build job on an ARM64 GitHub-hosted runner should reduce the cross-architecture overhead compared with running it on an amd64/x64 runner, while still targeting `linux/arm/v7` in Docker Buildx.

## Validation

- Parsed `.github/workflows/build.yml` successfully with Python/PyYAML.
- Staged and committed only `.github/workflows/build.yml`; existing untracked local files were left untouched.