### PR TITLE
cpan: exclude Math::Pari and Crypt::Random on arm/v7

### DIFF
--- a/Dockerfile-bookworm
+++ b/Dockerfile-bookworm
@@ -127,8 +127,8 @@ RUN --mount=type=cache,target=/root/.perl-cpm,id=${CPAN_CPM_CACHE_ID}-${TARGETAR
   if [ "${TARGETPLATFORM}" != "linux/amd64" ] && [ "${TARGETPLATFORM}" != "linux/386" ]; then
     sed -i '/Device::Firmata::Constants/d' /usr/src/app/core/cpanfile  
   fi
-  # Math::Pari emits 64-bit-only assembler on linux/386, Crypt::Random depends on it there.
-  if [ "${TARGETPLATFORM}" = "linux/386" ]; then
+  # Math::Pari/Crypt::Random are unstable on linux/386 and linux/arm/v7.
+  if [ "${TARGETPLATFORM}" = "linux/386" ] || [ "${TARGETPLATFORM}" = "linux/arm/v7" ]; then
     sed -i '/Math::Pari/d' /usr/src/app/core/cpanfile
     sed -i '/Crypt::Random/d' /usr/src/app/core/cpanfile
   fi

--- a/Dockerfile-bullseye
+++ b/Dockerfile-bullseye
@@ -108,8 +108,8 @@ RUN <<EOF
     sed -i '/Device::Firmata::Constants/d' /usr/src/app/core/cpanfile  
   fi
   
-  # Math::Pari emits 64-bit-only assembler on linux/386, Crypt::Random depends on it there.
-  if [ "${TARGETPLATFORM}" = "linux/386" ]; then
+  # Math::Pari/Crypt::Random are unstable on linux/386 and linux/arm/v7.
+  if [ "${TARGETPLATFORM}" = "linux/386" ] || [ "${TARGETPLATFORM}" = "linux/arm/v7" ]; then
     sed -i '/Math::Pari/d' /usr/src/app/core/cpanfile
     sed -i '/Crypt::Random/d' /usr/src/app/core/cpanfile
   fi

--- a/Dockerfile-threaded-bookworm
+++ b/Dockerfile-threaded-bookworm
@@ -127,8 +127,8 @@ RUN --mount=type=cache,target=/root/.perl-cpm,id=${CPAN_CPM_CACHE_ID}-${TARGETAR
   if [ "${TARGETPLATFORM}" != "linux/amd64" ] && [ "${TARGETPLATFORM}" != "linux/386" ]; then
     sed -i '/Device::Firmata::Constants/d' /usr/src/app/core/cpanfile  
   fi
-  # Math::Pari emits 64-bit-only assembler on linux/386, Crypt::Random depends on it there.
-  if [ "${TARGETPLATFORM}" = "linux/386" ]; then
+  # Math::Pari/Crypt::Random are unstable on linux/386 and linux/arm/v7.
+  if [ "${TARGETPLATFORM}" = "linux/386" ] || [ "${TARGETPLATFORM}" = "linux/arm/v7" ]; then
     sed -i '/Math::Pari/d' /usr/src/app/core/cpanfile
     sed -i '/Crypt::Random/d' /usr/src/app/core/cpanfile
   fi

--- a/Dockerfile-threaded-bullseye
+++ b/Dockerfile-threaded-bullseye
@@ -107,8 +107,8 @@ RUN <<EOF
   if [ "${TARGETPLATFORM}" != "linux/amd64" ] && [ "${TARGETPLATFORM}" != "linux/386" ]; then
     sed -i '/Device::Firmata::Constants/d' /usr/src/app/core/cpanfile  
   fi
-  # Math::Pari emits 64-bit-only assembler on linux/386, Crypt::Random depends on it there.
-  if [ "${TARGETPLATFORM}" = "linux/386" ]; then
+  # Math::Pari/Crypt::Random are unstable on linux/386 and linux/arm/v7.
+  if [ "${TARGETPLATFORM}" = "linux/386" ] || [ "${TARGETPLATFORM}" = "linux/arm/v7" ]; then
     sed -i '/Math::Pari/d' /usr/src/app/core/cpanfile
     sed -i '/Crypt::Random/d' /usr/src/app/core/cpanfile
   fi

--- a/README.md
+++ b/README.md
@@ -154,11 +154,11 @@ Some CPAN requirements are removed for specific image and platform combinations 
 | `*-bookworm`, `*-bullseye` | `linux/amd64` | none | none |
 | `*-bullseye` | `linux/386` | `Math::Pari`, `Crypt::Random`, `HiPi` | none |
 | `*-bookworm` | `linux/386` | `Math::Pari`, `Crypt::Random`, `HiPi` | `SNMP` |
-| `*-bookworm`, `*-bullseye` | `linux/arm/v7` | `Device::Firmata::Constants`, `HiPi` | `Device::Firmata::Constants`, `SNMP` |
+| `*-bookworm`, `*-bullseye` | `linux/arm/v7` | `Device::Firmata::Constants`, `Math::Pari`, `Crypt::Random`, `HiPi` | `Device::Firmata::Constants`, `SNMP` |
 | `*-bookworm` | `linux/arm64` | `Device::Firmata::Constants`, `HiPi` | `Device::Firmata::Constants`, `SNMP` |
 | `*-bullseye` | `linux/arm64` | `Device::Firmata::Constants`, `HiPi` | `Device::Firmata::Constants` |
 
-`Device::Firmata::Constants` is only kept on `linux/amd64` and `linux/386`. `Math::Pari` and `Crypt::Random` are removed on `linux/386` because `Math::Pari` emits 64-bit-only assembler there. `HiPi` is only kept on `linux/amd64`, because its dependency chain currently builds reliably only there. `SNMP` is removed where the CPAN module is not usable with the system Net-SNMP library version used by the image.
+`Device::Firmata::Constants` is only kept on `linux/amd64` and `linux/386`. `Math::Pari` and `Crypt::Random` are removed on `linux/386` and `linux/arm/v7` due runtime instability in `Math::Pari` on those platforms. `HiPi` is only kept on `linux/amd64`, because its dependency chain currently builds reliably only there. `SNMP` is removed where the CPAN module is not usable with the system Net-SNMP library version used by the image.
 
 
 ## Customize your container configuration

--- a/scripts/render-cpan-pr-comment.pl
+++ b/scripts/render-cpan-pr-comment.pl
@@ -89,7 +89,7 @@ sub excluded_requirements_for {
         push @thirdparty, 'Device::Firmata::Constants';
     }
 
-    if ( $target eq 'linux/386' ) {
+    if ( $target eq 'linux/386' || $target eq 'linux/arm/v7' ) {
         push @core, 'Math::Pari', 'Crypt::Random';
     }
 


### PR DESCRIPTION
## Summary
- exclude `Math::Pari` and `Crypt::Random` on `linux/arm/v7`
- apply exclusion consistently across all Dockerfile variants
- align CPAN PR report output and README exclusion matrix

## Context
In `arm/v7` CPAN verify artifacts, `Crypt::Random` fails to load because `Math::Pari` throws:
`PARI: incorrect type in gmul2n ... Math/Pari.pm line 1401`.

This is a runtime/load failure during verification, not a normal missing-install case.