### PR TITLE
Runtime-agnostic container detection for DockerImageInfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ fhem/restoreDir/*
 .vscode/*
 src/FHEM/trunk/*
 .cache/*
+downloaded-artifacts/

--- a/README.md
+++ b/README.md
@@ -281,6 +281,8 @@ It is enough for the `telnet` device to only listen on the loopback device (aka 
 
 The image comes with a built-in script to check availability, which communicates with the DockerImageInfo Definition.
 
+DockerImageInfo also reports the detected runtime in `container.runtime` and combines runtime and image metadata in the `model` reading, for example `runtime=kubernetes; image.version=5-bookworm; image.revision=...`. Runtime detection supports Kubernetes, Docker, container runtimes such as containerd, CRI-O and Podman, and `host` as fallback.
+
 If for whatever reason you want to disable checking a specific FHEMWEB instance, you may set the user attribute `DockerHealthCheck` to 0 on that particular FHEMWEB device.
 
 Note that the health check itself cannot be entirely disabled as it will ensure to notify you in case of failures, hindering proper shutdown of FHEM when triggered by Docker or OS shutdown procedure.

--- a/src/FHEM/99_DockerImageInfo.pm
+++ b/src/FHEM/99_DockerImageInfo.pm
@@ -17,6 +17,34 @@ sub DockerImageInfo_Initialize {
     return FHEM::Meta::InitMod( __FILE__, $hash );
 }
 
+sub DockerImageInfo_ReadFirstLine {
+    my ($path) = @_;
+
+    return q[] if ( !defined($path) || !-r $path );
+
+    my $fileHdl;
+    return q[] if ( !open( $fileHdl, q[<], $path ) );
+
+    my $line = <$fileHdl>;
+    close($fileHdl);
+
+    return q[] if ( !defined($line) );
+    chomp($line);
+
+    return $line;
+}
+
+sub DockerImageInfo_IsContainerized {
+    my $containerized = DockerImageInfo_ReadFirstLine(q[/containerized]);
+    my $runtime       = DockerImageInfo_ReadFirstLine(q[/container.runtime]);
+
+    return 1 if ( $containerized eq q[1] );
+    return 1 if ( $runtime =~ m/^(?:kubernetes|docker|containerd|cri-o|podman|container)$/x );
+    return 1 if ( -e q[/.dockerenv] );
+
+    return 0;
+}
+
 ###################################
 sub DockerImageInfo_Define {
     my ( $hash, $def ) = @_;
@@ -52,7 +80,7 @@ sub DockerImageInfo_Define {
         $attr{$name}{room}  = 'System';
     }
 
-    if ( -e '/.dockerenv' ) {
+    if ( DockerImageInfo_IsContainerized() ) {
         unlink( $hash->{URL_FILE});
         $hash->{STATE} = "Initialized";
         DockerImageInfo_GetImageInfo( $hash);
@@ -144,6 +172,7 @@ sub DockerImageInfo_GetImageInfo {
 
     my $NAME;
     my $VAL;
+    my %imageInfo;
     my @LINES = split( "\n", `sort -k1,1 -t'=' --stable --unique /image_info.* /image_info` );
 
     foreach my $LINE (@LINES) {
@@ -153,6 +182,7 @@ sub DockerImageInfo_GetImageInfo {
         $NAME =~ s/^org\.opencontainers\.//i;
         $VAL = join( "=", @NV );
         next if ( $NAME eq "image.authors" );
+        $imageInfo{$NAME} = $VAL;
         readingsBulkUpdateIfChanged( $hash, $NAME, $VAL );
     }
 
@@ -186,15 +216,29 @@ sub DockerImageInfo_GetImageInfo {
         readingsBulkUpdateIfChanged( $hash, 'id.groups', $VAL );
     }
 
-    readingsBulkUpdateIfChanged( $hash, q[ssh-id_ed25519.pub],    `cat ./.ssh/id_ed25519.pub` );
-    readingsBulkUpdateIfChanged( $hash, q[ssh-id_rsa.pub],        `cat ./.ssh/id_rsa.pub` );
-    readingsBulkUpdateIfChanged( $hash, q[container.hostname],    `cat /etc/hostname` );
-    readingsBulkUpdateIfChanged( $hash, q[container.cap.e],       `cat /docker.container.cap.e` );
-    readingsBulkUpdateIfChanged( $hash, q[container.cap.p],       `cat /docker.container.cap.p` );
-    readingsBulkUpdateIfChanged( $hash, q[container.cap.i],       `cat /docker.container.cap.i` );
-    readingsBulkUpdateIfChanged( $hash, q[container.id],          `cat /docker.container.id` );
-    readingsBulkUpdateIfChanged( $hash, q[container.privileged],  `cat /docker.privileged` );
-    readingsBulkUpdateIfChanged( $hash, q[container.hostnetwork], `cat /docker.hostnetwork` );
+    my $runtime = DockerImageInfo_ReadFirstLine(q[/container.runtime]);
+    $runtime = ( -e q[/.dockerenv] ) ? q[docker] : q[host] if ( $runtime eq q[] );
+
+    my $containerized = DockerImageInfo_ReadFirstLine(q[/containerized]);
+    $containerized = DockerImageInfo_IsContainerized() ? q[1] : q[0] if ( $containerized eq q[] );
+
+    readingsBulkUpdateIfChanged( $hash, q[ssh-id_ed25519.pub],    DockerImageInfo_ReadFirstLine(q[./.ssh/id_ed25519.pub]) );
+    readingsBulkUpdateIfChanged( $hash, q[ssh-id_rsa.pub],        DockerImageInfo_ReadFirstLine(q[./.ssh/id_rsa.pub]) );
+    readingsBulkUpdateIfChanged( $hash, q[container.hostname],    DockerImageInfo_ReadFirstLine(q[/etc/hostname]) );
+    readingsBulkUpdateIfChanged( $hash, q[container.runtime],     $runtime );
+    readingsBulkUpdateIfChanged( $hash, q[containerized],         $containerized );
+    readingsBulkUpdateIfChanged( $hash, q[container.cap.e],       DockerImageInfo_ReadFirstLine(q[/docker.container.cap.e]) );
+    readingsBulkUpdateIfChanged( $hash, q[container.cap.p],       DockerImageInfo_ReadFirstLine(q[/docker.container.cap.p]) );
+    readingsBulkUpdateIfChanged( $hash, q[container.cap.i],       DockerImageInfo_ReadFirstLine(q[/docker.container.cap.i]) );
+    readingsBulkUpdateIfChanged( $hash, q[container.id],          DockerImageInfo_ReadFirstLine(q[/docker.container.id]) );
+    readingsBulkUpdateIfChanged( $hash, q[container.privileged],  DockerImageInfo_ReadFirstLine(q[/docker.privileged]) );
+    readingsBulkUpdateIfChanged( $hash, q[container.hostnetwork], DockerImageInfo_ReadFirstLine(q[/docker.hostnetwork]) );
+
+    my @modelParts = ( qq[runtime=$runtime] );
+    for my $label (qw(image.title image.version image.revision image.source)) {
+        push( @modelParts, qq[$label=$imageInfo{$label}] ) if ( defined( $imageInfo{$label} ) && $imageInfo{$label} ne q[] );
+    }
+    readingsBulkUpdateIfChanged( $hash, q[model], join( q[; ], @modelParts ) );
 
     readingsEndUpdate( $hash, 1 );
 }
@@ -227,6 +271,12 @@ sub DockerImageInfo_GetImageInfo {
     <ul>
       <code>define DockerImageInfo DockerImageInfo</code>
     </ul>
+    <br><br>
+
+    The reading <code>model</code> summarizes the detected runtime and image metadata,
+    for example <code>runtime=kubernetes; image.version=5-bookworm; image.revision=...</code>.
+    The reading <code>container.runtime</code> contains <code>kubernetes</code>,
+    <code>docker</code>, <code>containerd</code>, <code>cri-o</code>, <code>podman</code> or <code>host</code>.
   </ul>
   <br>
 
@@ -272,6 +322,12 @@ sub DockerImageInfo_GetImageInfo {
     <ul>
       <code>define DockerImageInfo DockerImageInfo</code>
     </ul>
+    <br><br>
+
+    Das Reading <code>model</code> fasst die erkannte Runtime und Image-Metadaten zusammen,
+    zum Beispiel <code>runtime=kubernetes; image.version=5-bookworm; image.revision=...</code>.
+    Das Reading <code>container.runtime</code> enth&auml;lt <code>kubernetes</code>,
+    <code>docker</code>, <code>containerd</code>, <code>cri-o</code>, <code>podman</code> oder <code>host</code>.
   </ul>
 
   <a name="DockerImageInfoattr"></a>

--- a/src/entry.sh
+++ b/src/entry.sh
@@ -245,15 +245,59 @@ function getGlobalAttr() {
 
 
 
-# Collect information about the docker environment
+# Detect the container runtime without relying on Docker-specific marker files.
+#
+# Usage: detectContainerRuntime
+# Global vars: CONTAINER_RUNTIME
+#              CONTAINERIZED
+#
+function detectContainerRuntime() {
+  local dockerEnvFile="${DOCKER_ENV_FILE:-/.dockerenv}"
+  local kubernetesTokenFile="${KUBERNETES_TOKEN_FILE:-/var/run/secrets/kubernetes.io/serviceaccount/token}"
+  local cgroupFile="${CONTAINER_CGROUP_FILE:-/proc/1/cgroup}"
+  local mountInfoFile="${CONTAINER_MOUNTINFO_FILE:-/proc/self/mountinfo}"
+  local runtimeSource=""
+
+  [ -r "$cgroupFile" ] && runtimeSource="$(cat "$cgroupFile")"
+  [ -r "$mountInfoFile" ] && runtimeSource="${runtimeSource}
+$(cat "$mountInfoFile")"
+
+  if [ -f "$kubernetesTokenFile" ] || [ -n "${KUBERNETES_SERVICE_HOST-}" ] || grep -qaE 'kubepods' <<< "$runtimeSource"; then
+    export CONTAINER_RUNTIME=kubernetes
+    export CONTAINERIZED=1
+  elif [ -f "$dockerEnvFile" ] || grep -qaE 'docker' <<< "$runtimeSource"; then
+    export CONTAINER_RUNTIME=docker
+    export CONTAINERIZED=1
+  elif grep -qaE 'containerd' <<< "$runtimeSource"; then
+    export CONTAINER_RUNTIME=containerd
+    export CONTAINERIZED=1
+  elif grep -qaE 'cri-o|crio' <<< "$runtimeSource"; then
+    export CONTAINER_RUNTIME=cri-o
+    export CONTAINERIZED=1
+  elif grep -qaE 'libpod|podman' <<< "$runtimeSource"; then
+    export CONTAINER_RUNTIME=podman
+    export CONTAINERIZED=1
+  else
+    export CONTAINER_RUNTIME=host
+    export CONTAINERIZED=0
+  fi
+}
+
+
+# Collect information about the container environment
 #
 # Usage: collectDockerInfo
 # Global vars: DOCKER_PRIVILEGED
 #              DOCKER_GW
 #              DOCKER_HOST
 #              DOCKER_HOSTNETWORK
+#              CONTAINER_RUNTIME
+#              CONTAINERIZED
 #
 function collectDockerInfo() {
+  detectContainerRuntime
+  echo $CONTAINER_RUNTIME > /container.runtime
+  echo $CONTAINERIZED > /containerized
   if ip link add dummy0 type dummy >/dev/null 2>&1 ; then
     ip link delete dummy0 >/dev/null 2>&1
     export DOCKER_PRIVILEGED=1
@@ -262,7 +306,7 @@ function collectDockerInfo() {
   fi
   echo $DOCKER_PRIVILEGED > /docker.privileged
 
-  cat /proc/self/cgroup | grep "memory:" | cut -d "/" -f 3 > /docker.container.id
+  awk -F/ 'NF > 1 { print $NF; exit }' "${CONTAINER_CGROUP_FILE:-/proc/self/cgroup}" > /docker.container.id
   captest --text | grep -P "^Effective:" | cut -d " " -f 2- | sed "s/, /\n/g" | sort | sed ':a;N;$!ba;s/\n/,/g' > /docker.container.cap.e
   captest --text | grep -P "^Permitted:" | cut -d " " -f 2- | sed "s/, /\n/g" | sort | sed ':a;N;$!ba;s/\n/,/g' > /docker.container.cap.p
   captest --text | grep -P "^Inheritable:" | cut -d " " -f 2- | sed "s/, /\n/g" | sort | sed ':a;N;$!ba;s/\n/,/g' > /docker.container.cap.i

--- a/src/tests/bats/network.bats
+++ b/src/tests/bats/network.bats
@@ -11,13 +11,23 @@ setup() {
     declare -g DOCKER_GW=
     declare -g DOCKER_HOST=
     declare -g DOCKER_PRIVILEGED=
+    declare -g CONTAINER_RUNTIME=
+    declare -g CONTAINERIZED=
+    unset KUBERNETES_SERVICE_HOST
+
+    export DOCKER_ENV_FILE="${BATS_TEST_TMPDIR}/.dockerenv"
+    export KUBERNETES_TOKEN_FILE="${BATS_TEST_TMPDIR}/kubernetes-token"
+    export CONTAINER_CGROUP_FILE="${BATS_TEST_TMPDIR}/cgroup"
+    export CONTAINER_MOUNTINFO_FILE="${BATS_TEST_TMPDIR}/mountinfo"
+    rm -f "${DOCKER_ENV_FILE}" "${KUBERNETES_TOKEN_FILE}" "${CONTAINER_CGROUP_FILE}" "${CONTAINER_MOUNTINFO_FILE}"
+    touch "${CONTAINER_CGROUP_FILE}" "${CONTAINER_MOUNTINFO_FILE}"
 
     # copy default hosts file before every test
     cp  "${BATS_SUITE_TMPDIR}/hosts" "${HOSTS_FILE}"
 }
 
 
-setup_file() {   
+setup_file() {
     export BATS_TEST_TIMEOUT=60
     [ -z ${GITHUB_RUN_ID+x} ] || echo '::group::Network Tests' >&3
     export LOG_FILE="${BATS_SUITE_TMPDIR}/log"
@@ -26,21 +36,30 @@ setup_file() {
     source /entry.sh
     set +a
 
-    export CAP_E_FILE='/docker.container.cap.e'   
+    export CAP_E_FILE='/docker.container.cap.e'
     export CAP_P_FILE='/docker.container.cap.p'
     export CAP_I_FILE='/docker.container.cap.i'
     export HOSTNETWORK_FILE='/docker.hostnetwork'
     export PRIVILEDGED_FILE='/docker.privileged'
-    
+    export CONTAINER_RUNTIME_FILE='/container.runtime'
+    export CONTAINERIZED_FILE='/containerized'
+
 }
 
 teardown_file() {
     sleep 0
 
-    # Cleanup 
+    # Cleanup
     unset DOCKER_GW
     unset DOCKER_HOST
     unset DOCKER_PRIVILEGED
+    unset CONTAINER_RUNTIME
+    unset CONTAINERIZED
+    unset KUBERNETES_SERVICE_HOST
+    unset DOCKER_ENV_FILE
+    unset KUBERNETES_TOKEN_FILE
+    unset CONTAINER_CGROUP_FILE
+    unset CONTAINER_MOUNTINFO_FILE
     cp  "${BATS_SUITE_TMPDIR}/hosts" "${HOSTS_FILE}"
     [ -z ${GITHUB_RUN_ID+x} ] || echo '::endgroup::' >&3
 }
@@ -48,14 +67,83 @@ teardown_file() {
 
 
 teardown() {
-    rm -f ${CAP_E_FILE} ${CAP_P_FILE} ${CAP_I_FILE} ${HOSTNETWORK_FILE} ${PRIVILEDGED_FILE}
+    rm -f ${CAP_E_FILE} ${CAP_P_FILE} ${CAP_I_FILE} ${HOSTNETWORK_FILE} ${PRIVILEDGED_FILE} ${CONTAINER_RUNTIME_FILE} ${CONTAINERIZED_FILE}
+}
+
+# bats test_tags=unitTest
+@test "check detectContainerRuntime() - kubernetes from env" {
+    export KUBERNETES_SERVICE_HOST=10.96.0.1
+
+    detectContainerRuntime
+
+    assert_equal ${CONTAINER_RUNTIME} 'kubernetes'
+    assert_equal ${CONTAINERIZED} '1'
+}
+
+# bats test_tags=unitTest
+@test "check detectContainerRuntime() - kubernetes from serviceaccount token" {
+    touch "${KUBERNETES_TOKEN_FILE}"
+
+    detectContainerRuntime
+
+    assert_equal ${CONTAINER_RUNTIME} 'kubernetes'
+    assert_equal ${CONTAINERIZED} '1'
+}
+
+# bats test_tags=unitTest
+@test "check detectContainerRuntime() - docker from marker file" {
+    touch "${DOCKER_ENV_FILE}"
+
+    detectContainerRuntime
+
+    assert_equal ${CONTAINER_RUNTIME} 'docker'
+    assert_equal ${CONTAINERIZED} '1'
+}
+
+# bats test_tags=unitTest
+@test "check detectContainerRuntime() - kubernetes from cgroup" {
+    echo '0::/kubepods.slice/pod123/cri-containerd-abc.scope' > "${CONTAINER_CGROUP_FILE}"
+
+    detectContainerRuntime
+
+    assert_equal ${CONTAINER_RUNTIME} 'kubernetes'
+    assert_equal ${CONTAINERIZED} '1'
+}
+
+
+# bats test_tags=unitTest
+@test "check detectContainerRuntime() - containerd from cgroup" {
+    echo '0::/system.slice/containerd.service/containerd-abc.scope' > "${CONTAINER_CGROUP_FILE}"
+
+    detectContainerRuntime
+
+    assert_equal ${CONTAINER_RUNTIME} 'containerd'
+    assert_equal ${CONTAINERIZED} '1'
+}
+
+# bats test_tags=unitTest
+@test "check detectContainerRuntime() - cri-o from cgroup" {
+    echo '0::/system.slice/cri-o-abc.scope' > "${CONTAINER_CGROUP_FILE}"
+
+    detectContainerRuntime
+
+    assert_equal ${CONTAINER_RUNTIME} 'cri-o'
+    assert_equal ${CONTAINERIZED} '1'
+}
+
+# bats test_tags=unitTest
+@test "check detectContainerRuntime() - host fallback" {
+    detectContainerRuntime
+
+    assert_equal ${CONTAINER_RUNTIME} 'host'
+    assert_equal ${CONTAINERIZED} '0'
 }
 
 # bats test_tags=unitTest
 @test "check collectDockerInfo() - check cap files" {
     bats_require_minimum_version 1.5.0
     collectDockerInfo
-    
+
     assert_file_exists ${CAP_E_FILE}
     assert_file_exists ${CAP_P_FILE}
     assert_file_exists ${CAP_I_FILE}
@@ -86,7 +174,7 @@ teardown() {
 # bats test_tags=unitTest
 @test "check collectDockerInfo() - PRIVILEDGED file " {
     collectDockerInfo
-    
+
     assert_file_contains ${PRIVILEDGED_FILE} '0' grep
     assert_file_not_contains ${PRIVILEDGED_FILE} '1' grep
     assert_equal ${DOCKER_PRIVILEGED} '0'
@@ -109,7 +197,7 @@ teardown() {
 
 # bats test_tags=unitTest
 @test "check DOCKER_HOST in ${HOSTS_FILE}" {
-    collectDockerInfo 
+    collectDockerInfo
 
     run addDockerHosts
     assert_output --partial "Adding"
@@ -122,9 +210,9 @@ teardown() {
 # bats test_tags=unitTest
 @test "check DOCKER_GW in ${HOSTS_FILE}" {
     collectDockerInfo
-    
+
     run addDockerHosts
-    
+
     assert_file_contains ${HOSTS_FILE} "${DOCKER_GW}.*gateway.docker.internal" grep
 }
 
@@ -142,13 +230,13 @@ teardown() {
 # bats test_tags=hostMode,unitTest
 @test "check DOCKER_GW in ${HOSTS_FILE} with hostMode" {
     bats_require_minimum_version 1.5.0
-    
+
     collectDockerInfo
     run -0 addDockerHosts
-    
+
     assert_equal "${DOCKER_GW}" ""
     refute_output --partial "Adding gateway.docker.internal"
-    
-    cat "${HOSTS_FILE}" 
+
+    cat "${HOSTS_FILE}"
     assert_file_not_contains ${HOSTS_FILE} "${DOCKER_GW}.*gateway.docker.internal" grep
 }


### PR DESCRIPTION
## Summary

Fixes #431 by replacing Docker-specific container detection with a multi-signal runtime detection path in the entrypoint and DockerImageInfo module.

## Changes

- Detect Kubernetes, Docker, containerd, CRI-O, Podman, and host fallback in `entry.sh`.
- Persist runtime state in `/container.runtime` and `/containerized` while keeping existing `/docker.*` compatibility files.
- Update `DockerImageInfo` to initialize in non-Docker container runtimes and expose `container.runtime`, `containerized`, and a `model` reading composed from runtime plus OCI image labels.
- Document the new readings and ignore locally downloaded GitHub Actions artifacts used for CPAN test builds.
- Add Bats coverage for runtime detection signals.

## Validation

- `git diff --check`
- `bash -n src/entry.sh`
- FHEM module syntax load with FHEM core stubs
- Bats image test reported successful locally
- Kubernetes smoke test with kind:
  - `/container.runtime = kubernetes`
  - `/containerized = 1`
  - `model = runtime=kubernetes; image.title=fhem-linux/amd64; image.version=issue431; image.revision=9d1a1f3; image.source=https://github.com/fhem/fhem-docker/`

## Notes

The original image tag is not available reliably inside a running container. The `model` reading therefore uses OCI image labels such as `image.version` and `image.revision`, which are embedded during the image build.