### PR TITLE
fix(bookworm): drop unusable C headers to clear linux-libc-dev CVEs

### DIFF
--- a/Dockerfile-bookworm
+++ b/Dockerfile-bookworm
@@ -210,12 +210,28 @@ RUN <<EOF
         unzip \
         usbutils \
         wget \
-        libarchive-dev \
+        libarchive13 \
         bash \
         libgd3 \
         librsvg2-2 \
         iproute2 \
         libpq5
+    # The upstream Perl base image ships a C header toolchain (libc6-dev and
+    # friends) so that XS modules can be compiled inside the container. This
+    # image carries no C compiler, so those headers can never be used -- but
+    # they keep dragging kernel and OpenSSL CVEs (linux-libc-dev, libssl-dev)
+    # into every image scan. The base tag is pinned to an end-of-life Perl
+    # release, so no rebuilt upstream tag will ever ship fixed versions of
+    # them. Drop the headers here; the matching runtime libraries (libc6,
+    # libssl3, zlib1g, libarchive13) stay installed.
+    # Their auto-installed companions (libc-dev-bin, libnsl-dev, libtirpc-dev,
+    # rpcsvc-proto) are taken by the autoremove below.
+    LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get purge -qqy \
+        linux-libc-dev \
+        libc6-dev \
+        libcrypt-dev \
+        libssl-dev \
+        zlib1g-dev
     LC_ALL=C apt-get autoremove -qqy && LC_ALL=C apt-get clean 
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* ~/.[!.] ~/.??* ~/*
 EOF
@@ -356,7 +372,6 @@ RUN <<EOF
     LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get update 
     LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get install -qqy --no-install-recommends \
       python3 \
-      python3-dev \
       python3-pip \
       python3-setuptools \
       python3-wheel \

--- a/Dockerfile-threaded-bookworm
+++ b/Dockerfile-threaded-bookworm
@@ -210,12 +210,28 @@ RUN <<EOF
         unzip \
         usbutils \
         wget \
-        libarchive-dev \
+        libarchive13 \
         bash \
         libgd3 \
         librsvg2-2 \
         iproute2 \
         libpq5
+    # The upstream Perl base image ships a C header toolchain (libc6-dev and
+    # friends) so that XS modules can be compiled inside the container. This
+    # image carries no C compiler, so those headers can never be used -- but
+    # they keep dragging kernel and OpenSSL CVEs (linux-libc-dev, libssl-dev)
+    # into every image scan. The base tag is pinned to an end-of-life Perl
+    # release, so no rebuilt upstream tag will ever ship fixed versions of
+    # them. Drop the headers here; the matching runtime libraries (libc6,
+    # libssl3, zlib1g, libarchive13) stay installed.
+    # Their auto-installed companions (libc-dev-bin, libnsl-dev, libtirpc-dev,
+    # rpcsvc-proto) are taken by the autoremove below.
+    LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get purge -qqy \
+        linux-libc-dev \
+        libc6-dev \
+        libcrypt-dev \
+        libssl-dev \
+        zlib1g-dev
     LC_ALL=C apt-get autoremove -qqy && LC_ALL=C apt-get clean 
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* ~/.[!.] ~/.??* ~/*
 EOF
@@ -356,7 +372,6 @@ RUN <<EOF
     LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get update 
     LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get install -qqy --no-install-recommends \
       python3 \
-      python3-dev \
       python3-pip \
       python3-setuptools \
       python3-wheel \


### PR DESCRIPTION
## Problem

Trivy reports several CVEs against `linux-libc-dev` in the bookworm images, e.g.

```
CVE-2026-53138 │ HIGH │ fixed │ 6.1.176-1 │ 6.1.177-1
kernel: drm/amd/display: Bound VBIOS record-chain walk loops
```

The package does not come from this repository. It is inherited from the
upstream Perl base image, which ships a C header toolchain so that XS modules
can be compiled inside the container:

```
perl:5.38.5-slim-bookworm → libc6-dev, linux-libc-dev, libssl-dev,
                            zlib1g-dev, libcrypt-dev, libnsl-dev, ...
```

A fixed base tag will never arrive: the tag is pinned to Perl 5.38, which is
end-of-life upstream, so no rebuilt image is published.

The key observation is that **the runtime image contains no C compiler** —
`cc`, `gcc` and `g++` are all absent, only `make` is present. The headers can
therefore never be used for anything. They are roughly 36 MB of dead weight
that drags kernel and OpenSSL CVEs into every scan. `linux-libc-dev` contains
only `.h` files; the CVE concerns the host kernel, never the container.

## Change

Applied to `Dockerfile-bookworm` and `Dockerfile-threaded-bookworm`:

1. **Purge the inherited header toolchain** in the `base-cpan` stage:
   `linux-libc-dev`, `libc6-dev`, `libcrypt-dev`, `libssl-dev`, `zlib1g-dev`.
   Their auto-installed companions (`libc-dev-bin`, `libnsl-dev`,
   `libtirpc-dev`, `rpcsvc-proto`) are taken by the `autoremove` that already
   follows. The matching runtime libraries (`libc6`, `libssl3`, `zlib1g`,
   `libarchive13`) stay installed.
2. **`libarchive-dev` → `libarchive13`.** Only the runtime library was ever
   needed; no cpanfile requires the headers. The `-dev` package has been in
   here since the first bookworm Dockerfile without a consumer.
3. **Drop `python3-dev`.** It would pull `libc6-dev` and thus `linux-libc-dev`
   straight back into the full image, and is equally unusable without a
   compiler.

The deprecated `CPAN_PKGS` / `PIP_PKGS` runtime install paths in `entry.sh`
could not build C extensions before this change either, for lack of a
compiler — pure-Perl and pure-Python packages are unaffected.

## Scope

Bullseye is deliberately left untouched.

Worth noting separately: bullseye builds are currently broken for an unrelated,
pre-existing reason — `deb.debian.org/debian-security` returns 404 for
`libperl5.32`, `avahi-daemon` and `libavahi-common-data` since Debian 11 moved
to the archive.

## Verification

The patched `base-cpan` stage was replayed against both real base images
(`perl:5.38.5-slim-bookworm` and `perl:5.38.5-slim-threaded-bookworm`):

| Check | bookworm | threaded-bookworm |
|---|---|---|
| apt errors | none | none |
| remaining `-dev` packages | none | none |
| smoke test | perl, IO::Socket::SSL, sqlite3, svn, mysql | perl, sqlite3, svn |
| `useithreads` | — | `define` |

An earlier draft that also listed `rpcsvc-proto` was dropped: that package does
not exist in bullseye and `apt-get purge` aborts hard on an unknown name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3oE4DmgZNsmXsTtCP4Z45
