### PR TITLE
fix: keep logfile forwarding after recreation

### DIFF
--- a/src/entry.sh
+++ b/src/entry.sh
@@ -106,6 +106,7 @@ function waitForTextInFile() {
 
 # Prints content added to a file to stdout while running in the background.
 # Robust against truncation and (initial) non-existance of the file.
+# Follow the file name so logging continues after FHEM deletes/recreates it.
 #
 # Usage: tailFileToConsoleStart file [-b]
 # Parameters:  file   File to print
@@ -118,9 +119,9 @@ function tailFileToConsoleStart() {
   local inFlag="${2:-}"
   tailFileToConsoleStop
   if [ "$inFlag" == "-b" ]; then
-    { tail -n +0 --retry -s 0.1 -f "$inLogFile" 2>/dev/null | grep --line-buffered '^.*$' & } 2>/dev/null # grep is used for line buffering as tail lost this option.
+    { tail -n +0 --retry -s 0.1 -F "$inLogFile" 2>/dev/null & } 2>/dev/null
   else
-    { tail -n0 --retry -s 0.1 -f "$inLogFile" 2>/dev/null | grep --line-buffered '^.*$' & } 2>/dev/null # grep is used for line buffering as tail lost this option.
+    { tail -n0 --retry -s 0.1 -F "$inLogFile" 2>/dev/null & } 2>/dev/null
   fi
   gCurrentTailFile="$inLogFile"
   gCurrentTailPid=$!

--- a/src/tests/bats/entry.bats
+++ b/src/tests/bats/entry.bats
@@ -126,6 +126,9 @@ teardown() {
     run bash -c 'tailFileToConsoleStart ${realLogFile}; sleep 1; echo "again" >> $realLogFile; sleep 1; tailFileToConsoleStop'
     assert_output "again"
     refute_output "hello"
+
+    run bash -c 'tailFileToConsoleStart ${realLogFile}; sleep 1; rm $realLogFile; echo "recreated" > $realLogFile; sleep 1; tailFileToConsoleStop'
+    assert_output "recreated"
 }
 
 # bats test_tags=integrationTest


### PR DESCRIPTION
FHEM can delete and recreate its logfile at runtime.

The entrypoint currently forwards logs with `tail -f ... | grep --line-buffered`.
In Kubernetes this can stop forwarding current FHEM messages to container stdout after the logfile is recreated.

This changes the forwarding to use `tail -F` directly, so it follows the logfile path across recreation and keeps container logs current.

Validation:
- `bash -n src/entry.sh`
- direct function check: append to logfile is forwarded
- direct function check: delete/recreate logfile is forwarded