### PR TITLE
fix: keep logfile forwarding after recreation

### DIFF
--- a/src/entry.sh
+++ b/src/entry.sh
@@ -86,6 +86,7 @@ function waitForPidToTerminate() {
 
 # Searches for a text being newly appended to a file, optionally limited by a timeout.
 # Robust against truncation and (initial) non-existance of the file.
+# Follow the file name so the search continues after FHEM deletes/recreates it.
 #
 # Usage: waitForTextInFile file searchText [timeout]
 # Parameters:  file         File to search in
@@ -99,7 +100,7 @@ function waitForTextInFile() {
   local    inFile="$1"
   local    inSearchText="$2"
   local -i inTimeout=${3:-0}  # Wait indefinitely is default
-  local    bashCmd="tail -n0 --retry -f '$inFile' 2>/dev/null | sed -e '/$inSearchText/ q' > /dev/null"
+  local    bashCmd="tail -n0 --retry -F '$inFile' 2>/dev/null | sed -e '/$inSearchText/ q' > /dev/null"
   timeout $inTimeout bash -c "$bashCmd"
 }
 

--- a/src/entry.sh
+++ b/src/entry.sh
@@ -106,6 +106,7 @@ function waitForTextInFile() {
 
 # Prints content added to a file to stdout while running in the background.
 # Robust against truncation and (initial) non-existance of the file.
+# Follow the file name so logging continues after FHEM deletes/recreates it.
 #
 # Usage: tailFileToConsoleStart file [-b]
 # Parameters:  file   File to print
@@ -118,9 +119,9 @@ function tailFileToConsoleStart() {
   local inFlag="${2:-}"
   tailFileToConsoleStop
   if [ "$inFlag" == "-b" ]; then
-    { tail -n +0 --retry -s 0.1 -f "$inLogFile" 2>/dev/null | grep --line-buffered '^.*$' & } 2>/dev/null # grep is used for line buffering as tail lost this option.
+    { tail -n +0 --retry -s 0.1 -F "$inLogFile" 2>/dev/null & } 2>/dev/null
   else
-    { tail -n0 --retry -s 0.1 -f "$inLogFile" 2>/dev/null | grep --line-buffered '^.*$' & } 2>/dev/null # grep is used for line buffering as tail lost this option.
+    { tail -n0 --retry -s 0.1 -F "$inLogFile" 2>/dev/null & } 2>/dev/null
   fi
   gCurrentTailFile="$inLogFile"
   gCurrentTailPid=$!

--- a/src/tests/bats/entry.bats
+++ b/src/tests/bats/entry.bats
@@ -126,6 +126,9 @@ teardown() {
     run bash -c 'tailFileToConsoleStart ${realLogFile}; sleep 1; echo "again" >> $realLogFile; sleep 1; tailFileToConsoleStop'
     assert_output "again"
     refute_output "hello"
+
+    run bash -c 'tailFileToConsoleStart ${realLogFile}; sleep 1; rm $realLogFile; echo "recreated" > $realLogFile; sleep 1; tailFileToConsoleStop'
+    assert_output "recreated"
 }
 
 # bats test_tags=integrationTest

--- a/src/tests/bats/entry.bats
+++ b/src/tests/bats/entry.bats
@@ -131,6 +131,19 @@ teardown() {
     assert_output "recreated"
 }
 
+# bats test_tags=unitTest
+@test "check waitForTextInFile() after logfile recreation" {
+    export searchLogFile="${BATS_TEST_TMPDIR}/waitfor.log"
+    echo "some old content" > $searchLogFile
+
+    # FHEM can delete and recreate its logfile, the awaited text then only
+    # shows up in the newly created file.
+    ( sleep 1; rm -f $searchLogFile; echo "Server started" > $searchLogFile ) >/dev/null 2>&1 &
+
+    run waitForTextInFile $searchLogFile "Server started" 10
+    assert_success
+}
+
 # bats test_tags=integrationTest
 @test "Setup clean install FHEM" {
     


### PR DESCRIPTION
Upstream copy of #503 by @stormmurdoc, pushed to a branch in this repository so the full CI pipeline can run.

The fork-based PR #503 cannot pass CI: fork pull requests get a read-only `GITHUB_TOKEN`, so `build_test_images` fails to push the ephemeral CI images to `ghcr.io/fhem/fhem-docker-ci` (`denied: installation not allowed to Write organization package`) and the `cpan_build` PR comment step fails with `403 Resource not accessible by integration`. All downstream test jobs are then skipped. The commit itself is unchanged and authorship is preserved.

## Original description

FHEM can delete and recreate its logfile at runtime.

The entrypoint currently forwards logs with `tail -f ... | grep --line-buffered`.
In Kubernetes this can stop forwarding current FHEM messages to container stdout after the logfile is recreated.

This changes the forwarding to use `tail -F` directly, so it follows the logfile path across recreation and keeps container logs current.

Validation:
- `bash -n src/entry.sh`
- direct function check: append to logfile is forwarded
- direct function check: delete/recreate logfile is forwarded

## Review notes

Reproduced locally with the original code (GNU coreutils 9.4, pipe as stdout as in the container):

```
--- old (tail -f | grep --line-buffered) ---   --- new (tail -F) ---
before-recreate                                before-recreate
                                               after-recreate
                                               another-line
```

- Dropping `grep` is safe: GNU `tail` flushes after every read batch in follow mode; measured write-to-visible latency was ~6 ms even with a pipe instead of a TTY. `--line-buffered` never existed as a `tail` option, so the comment it replaced described a non-issue.
- `gCurrentTailPid=$!` used to hold the `grep` PID (last element of the pipeline), so `tailFileToConsoleStop` only killed `grep` and left `tail` running until its next SIGPIPE. It now kills `tail` directly, which matters because `keepFhemRunning` restarts the tail on logfile name changes.
- `--retry` is now redundant next to `-F` (harmless). The previous `-f --retry` combination actually emitted a `--retry only effective for the initial open` warning that was hidden by `2>/dev/null`.

The added bats test is a real regression test: it fails with the old code and passes with the new one.

## Second commit: same fix for `waitForTextInFile`

`waitForTextInFile()` (`src/entry.sh:102`) had the same `-f` problem. `startFhemProcess()` calls it right after launching FHEM to wait for the `Server started` message. If FHEM recreates its logfile in that window, the search stays on the old inode and the container aborts with `Fatal: No message from FHEM since $TIMEOUT_STARTING seconds that server has started.` although FHEM came up fine — the same failure mode as above, but with a startup abort instead of silent log loss.

Measured against the real function sourced from `src/entry.sh`:

| case | `-f` (before) | `-F` (after) |
|---|---|---|
| logfile deleted and recreated, text in the new file | `rc=124` after the full timeout | `rc=0` after ~1s |
| plain append, no recreation | `rc=0` | `rc=0` |
| text never appears | `rc=124` | `rc=124` |

So the recreation case is fixed while the normal path and the documented `124` timeout return value are unchanged. The accompanying bats test hits the timeout with the old code and passes with the new one.

## Known follow-up

`src/tests/bats/entry.bats` uses CRLF line endings while the lines added in the first commit use LF, which is why the diff shows three unchanged lines as a replacement. That gets its own PR — this one stays about the `-F` fix.

Closes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3oE4DmgZNsmXsTtCP4Z45
