### PR TITLE
fix: keep startup wait working after logfile recreation

### DIFF
--- a/src/entry.sh
+++ b/src/entry.sh
@@ -86,6 +86,7 @@ function waitForPidToTerminate() {
 
 # Searches for a text being newly appended to a file, optionally limited by a timeout.
 # Robust against truncation and (initial) non-existance of the file.
+# Follow the file name so the search continues after FHEM deletes/recreates it.
 #
 # Usage: waitForTextInFile file searchText [timeout]
 # Parameters:  file         File to search in
@@ -99,7 +100,7 @@ function waitForTextInFile() {
   local    inFile="$1"
   local    inSearchText="$2"
   local -i inTimeout=${3:-0}  # Wait indefinitely is default
-  local    bashCmd="tail -n0 --retry -f '$inFile' 2>/dev/null | sed -e '/$inSearchText/ q' > /dev/null"
+  local    bashCmd="tail -n0 --retry -F '$inFile' 2>/dev/null | sed -e '/$inSearchText/ q' > /dev/null"
   timeout $inTimeout bash -c "$bashCmd"
 }
 

--- a/src/tests/bats/entry.bats
+++ b/src/tests/bats/entry.bats
@@ -128,6 +128,19 @@ teardown() {
     refute_output "hello"
 }
 
+# bats test_tags=unitTest
+@test "check waitForTextInFile() after logfile recreation" {
+    export searchLogFile="${BATS_TEST_TMPDIR}/waitfor.log"
+    echo "some old content" > $searchLogFile
+
+    # FHEM can delete and recreate its logfile, the awaited text then only
+    # shows up in the newly created file.
+    ( sleep 1; rm -f $searchLogFile; echo "Server started" > $searchLogFile ) >/dev/null 2>&1 &
+
+    run waitForTextInFile $searchLogFile "Server started" 10
+    assert_success
+}
+
 # bats test_tags=integrationTest
 @test "Setup clean install FHEM" {
     


### PR DESCRIPTION
Follow-up to #504, kept separate because it touches a different function and #504 should stay a clean copy of @stormmurdoc's commit.

`waitForTextInFile()` uses `tail -n0 --retry -f`, which follows the file *descriptor*. `startFhemProcess()` calls it right after launching FHEM to wait for the `Server started` message:

```
if ! waitForTextInFile "$gCurrentTailFile" "Server started" $TIMEOUT_STARTING ; then
```

If FHEM deletes and recreates its logfile in that window, the search stays on the old inode, never sees the message, and the container aborts with `Fatal: No message from FHEM since $TIMEOUT_STARTING seconds that server has started.` — even though FHEM came up fine. This is the same failure mode #504 fixes for the log forwarding, just with a startup abort instead of silent log loss.

Following the file name with `-F` fixes it. `--retry` is now redundant next to `-F` but kept for a minimal diff, consistent with #504.

## Validation

Measured against the real function sourced from `src/entry.sh`:

| case | `-f` (before) | `-F` (after) |
|---|---|---|
| logfile deleted and recreated, text in the new file | `rc=124` after the full timeout | `rc=0` after ~1s |
| plain append, no recreation | `rc=0` | `rc=0` |
| text never appears | `rc=124` | `rc=124` |

So the recreation case is fixed and both the normal path and the documented `124` timeout return value are unchanged.

The added bats test is a real regression test: it hits the timeout with the old code and passes with the new one. It uses CRLF line endings to match the rest of `src/tests/bats/entry.bats`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3oE4DmgZNsmXsTtCP4Z45
