### PR TITLE
ci: start a fresh run when the publishImage label is added

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,10 @@ on:
 
   pull_request:
     branches: [ dev ]
+    # 'labeled' is needed so adding publishImage starts a fresh run. Re-running
+    # an existing run replays its original event payload, which does not yet
+    # contain the label, so the publish steps would still evaluate push: false.
+    types: [opened, synchronize, reopened, labeled]
 
   release:
     types: 
@@ -26,7 +30,9 @@ on:
 # sweeping images for that same branch. Release runs are never cancelled.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'release' && github.run_id || (github.event.pull_request.number || github.ref) }}
-  cancel-in-progress: ${{ github.event_name != 'release' }}
+  # A 'labeled' run for any other label has all of its jobs skipped, so it must
+  # not cancel a real build that is still in flight - let it queue instead.
+  cancel-in-progress: ${{ github.event_name != 'release' && (github.event.action != 'labeled' || contains(github.event.pull_request.labels.*.name, 'publishImage')) }}
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 env:
@@ -37,6 +43,9 @@ env:
 
 jobs:
   docker_lint:
+    # Actions cannot filter 'labeled' by label name, so drop runs triggered by
+    # any other label instead of spending a full multi-arch build on them.
+    if: github.event.action != 'labeled' || contains(github.event.pull_request.labels.*.name, 'publishImage')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repository
@@ -56,6 +65,9 @@ jobs:
 
   get_dependencies:
     # Min Version for the prereq scanner to ignore core modules
+    # Actions cannot filter 'labeled' by label name, so drop runs triggered by
+    # any other label instead of spending a full multi-arch build on them.
+    if: github.event.action != 'labeled' || contains(github.event.pull_request.labels.*.name, 'publishImage')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repository
@@ -136,6 +148,9 @@ jobs:
           overwrite: true
 
   base_build:
+    # Actions cannot filter 'labeled' by label name, so drop runs triggered by
+    # any other label instead of spending a full multi-arch build on them.
+    if: github.event.action != 'labeled' || contains(github.event.pull_request.labels.*.name, 'publishImage')
     strategy:
       matrix:
         dockerfile: [-bookworm, -threaded-bookworm]


### PR DESCRIPTION
Split out of #504 as requested — this is CI plumbing, not part of the `tail -F` fix.

## Problem

Adding the `publishImage` label to a PR does nothing today, as seen on #504:

- `on.pull_request` has no explicit `types`, so it only fires for `opened`, `synchronize` and `reopened`. Adding a label starts **no run at all**.
- Re-running the existing run does not help either: a re-run replays the *original* event payload, which does not contain the label yet. `contains(github.event.pull_request.labels.*.name, 'publishImage')` stays false and the publish steps build with `push: false`.

Measured on #504, where the label was added at `06:20:44Z` and the run restarted at `06:21:24Z`:

| run | trigger | `published_build` push steps |
|---|---|---|
| `34276838742` attempt 2 | re-run, label already on the PR | `push: false` |
| `34321878471` | new commit pushed after labelling | `push: true` → `ghcr.io/fhem/fhem-docker:pr-504-bookworm`, `:pr-504-threaded-bookworm` |

So the only way to publish a PR image right now is to push a commit *after* labelling, which is exactly the workaround this PR removes.

## Change

1. `types: [opened, synchronize, reopened, labeled]` on the `pull_request` trigger.
2. Actions cannot filter a `labeled` event by label name, and a full run here means four architectures plus CPAN builds. So the three root jobs — `docker_lint`, `get_dependencies`, `base_build` — carry:

   ```yaml
   if: github.event.action != 'labeled' || contains(github.event.pull_request.labels.*.name, 'publishImage')
   ```

   Every other job reaches these three through `needs`, so an unrelated label skips the entire run rather than just its first jobs.
3. The same condition guards `cancel-in-progress`. Without it, labelling a PR while a build is running would spawn a run that is skipped immediately but has already cancelled the real build. With it, such a run queues instead.

## Behaviour matrix

| event | `github.event.action` | guard | result |
|---|---|---|---|
| `push` to `dev*` / `master` | absent | true | unchanged |
| PR opened / synchronize / reopened | not `labeled` | true | unchanged |
| PR labelled `publishImage` | `labeled` | true | full run, images published |
| PR labelled anything else | `labeled` | false | all jobs skipped, no build minutes spent |
| `release` published / released | `published` / `released` | true | unchanged |
| `workflow_dispatch` | absent | true | unchanged |

## Validation

`actionlint` (which validates `if:` expressions and context access, not just YAML) reports **17 findings before and 17 after** — all pre-existing shellcheck style hints in unrelated `run:` blocks, none in the touched lines. The file keeps its CRLF line endings (1336/1336 lines), so the diff stays limited to the four hunks above.

The `labeled` path itself can only be exercised by actually labelling a PR once this is on `dev` — happy to verify it on the next PR that needs an image.


